### PR TITLE
Fix gravity getter and setter

### DIFF
--- a/magick/init.lua
+++ b/magick/init.lua
@@ -90,7 +90,7 @@ local gravity_str = {
 }
 local gravity_type = { }
 for i, t in ipairs(gravity_str) do
-  gravity_type[t] = i
+  gravity_type[t] = i - 1
 end
 lib.MagickWandGenesis()
 local filter
@@ -154,7 +154,7 @@ do
       return handle_result(self, lib.MagickSetOption(self.wand, format, value))
     end,
     get_gravity = function(self)
-      return gravity_str[lib.MagickGetImageGravity(self.wand)]
+      return gravity_str[lib.MagickGetImageGravity(self.wand) + 1]
     end,
     set_gravity = function(self, typestr)
       local type = gravity_type[typestr]

--- a/magick/init.moon
+++ b/magick/init.moon
@@ -92,7 +92,7 @@ gravity_str = {
 gravity_type = {}
 
 for i, t in ipairs gravity_str
-  gravity_type[t] = i
+  gravity_type[t] = i - 1
 
 lib.MagickWandGenesis!
 
@@ -142,7 +142,7 @@ class Image
       lib.MagickSetOption @wand, format, value
 
   get_gravity: =>
-    gravity_str[lib.MagickGetImageGravity @wand]
+    gravity_str[(lib.MagickGetImageGravity @wand) + 1]
 
   set_gravity: (typestr) =>
      type = gravity_type[typestr]


### PR DESCRIPTION
Lua tables start at index 1, the old code was using the table position as a way
to get/set the value for gravity, which led to an off by 1 error

`typedef` in ImageMagick source for reference: http://git.imagemagick.org/repos/ImageMagick/blob/master/MagickCore/geometry.h#L76-89