### PR TITLE
add reset_page()

### DIFF
--- a/magick/wand/image.lua
+++ b/magick/wand/image.lua
@@ -224,6 +224,9 @@ do
     auto_orient = function(self)
       return handle_result(self, lib.MagickAutoOrientImage(self.wand))
     end,
+    reset_page = function(self)
+      return handle_result(self, lib.MagickResetImagePage(self.wand, nil))
+    end,
     __tostring = function(self)
       return "Image<" .. tostring(self.path) .. ", " .. tostring(self.wand) .. ">"
     end

--- a/magick/wand/image.moon
+++ b/magick/wand/image.moon
@@ -195,6 +195,9 @@ class Image extends require "magick.base_image"
   auto_orient: =>
     handle_result @, lib.MagickAutoOrientImage @wand
 
+  reset_page: =>
+    handle_result @, lib.MagickResetImagePage @wand, nil
+
   __tostring: =>
     "Image<#{@path}, #{@wand}>"
 

--- a/magick/wand/lib.lua
+++ b/magick/wand/lib.lua
@@ -105,6 +105,8 @@ ffi.cdef([[  typedef void MagickWand;
     const InterlaceType interlace_scheme);
 
   MagickBooleanType MagickAutoOrientImage(MagickWand *wand);
+
+  MagickBooleanType MagickResetImagePage(MagickWand *wand, const char *page);
 ]])
 local get_flags
 get_flags = function()

--- a/magick/wand/lib.moon
+++ b/magick/wand/lib.moon
@@ -109,6 +109,8 @@ ffi.cdef [[
     const InterlaceType interlace_scheme);
 
   MagickBooleanType MagickAutoOrientImage(MagickWand *wand);
+
+  MagickBooleanType MagickResetImagePage(MagickWand *wand, const char *page);
 ]]
 
 


### PR DESCRIPTION
When using `crop`, it doesn't repage the image so the resulting image typically keeps the original image dimensions for me.
I may be missing something but I didn't see a way to repage the image afterwards. Is there?
This adds a way to repage it if needed.