### PR TITLE
add get and set image profile to image magick

### DIFF
--- a/magick/wand/image.lua
+++ b/magick/wand/image.lua
@@ -238,6 +238,14 @@ do
       itype = assert(interlace:to_int(itype), "invalid interlace type")
       return lib.MagickSetImageInterlaceScheme(self.wand, itype)
     end,
+    get_profile = function(self, profile)
+      local len = ffi.new("size_t[1]", 0)
+      local blob = ffi.gc(lib.MagickGetImageProfile(self.wand, profile, len), lib.MagickRelinquishMemory)
+      return ffi.string(blob, len[0])
+    end,
+    set_profile = function(self, profile, value)
+      return handle_result(self, lib.MagickSetImageProfile(self.wand, profile, value, #value))
+    end,
     auto_orient = function(self)
       return handle_result(self, lib.MagickAutoOrientImage(self.wand))
     end,

--- a/magick/wand/lib.lua
+++ b/magick/wand/lib.lua
@@ -114,6 +114,12 @@ ffi.cdef([[  typedef void MagickWand;
   MagickBooleanType MagickSetImageDepth(MagickWand *,const unsigned long);
   unsigned long MagickGetImageDepth(MagickWand *);
 
+  unsigned char *MagickGetImageProfile(MagickWand *wand,const char *name,
+  size_t *length);
+
+  MagickBooleanType MagickSetImageProfile(MagickWand *wand,const char *name,
+  const void *profile,const size_t length);
+
 ]])
 local get_flags
 get_flags = function()


### PR DESCRIPTION
the PR adds support for processing image profile with get/set method provided by ImageMagick:
[http://www.imagemagick.org/api/MagickWand/magick-property_8c_source.html#l0678](url)
[http://www.imagemagick.org/api/MagickWand/magick-property_8c_source.html#l02320](url)