### PR TITLE
MagickBooleanType is missed in MagickCompositeImage

### DIFF
--- a/magick/wand/image.lua
+++ b/magick/wand/image.lua
@@ -171,7 +171,7 @@ do
         blob = blob.wand
       end
       op = assert(composite_operators:to_int(op), "invalid operator type")
-      return handle_result(self, lib.MagickCompositeImage(self.wand, blob, op, x, y))
+      return handle_result(self, lib.MagickCompositeImage(self.wand, blob, op, 1, x, y))
     end,
     get_blob = function(self)
       local len = ffi.new("size_t[1]", 0)

--- a/magick/wand/image.moon
+++ b/magick/wand/image.moon
@@ -135,7 +135,7 @@ class Image extends require "magick.base_image"
 
     op = assert composite_operators\to_int(op), "invalid operator type"
     handle_result @,
-      lib.MagickCompositeImage @wand, blob, op, x, y
+      lib.MagickCompositeImage @wand, blob, op, 1, x, y
 
   get_blob: =>
     len = ffi.new "size_t[1]", 0

--- a/magick/wand/lib.lua
+++ b/magick/wand/lib.lua
@@ -61,6 +61,7 @@ ffi.cdef([[  typedef void MagickWand;
 
   MagickBooleanType MagickCompositeImage(MagickWand *wand,
     const MagickWand *source_wand,const CompositeOperator compose,
+    const MagickBooleanType,
     const ssize_t x,const ssize_t y);
 
   GravityType MagickGetImageGravity(MagickWand *wand);

--- a/magick/wand/lib.moon
+++ b/magick/wand/lib.moon
@@ -65,6 +65,7 @@ ffi.cdef [[
 
   MagickBooleanType MagickCompositeImage(MagickWand *wand,
     const MagickWand *source_wand,const CompositeOperator compose,
+    const MagickBooleanType,
     const ssize_t x,const ssize_t y);
 
   GravityType MagickGetImageGravity(MagickWand *wand);


### PR DESCRIPTION
fix implement C-call MagickCompositeImage of libmagickwand, need 6 params, MagickBooleanType is missed