### PR TITLE
refactor: port to *Lua* v5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	busted
 
 local: build
-	luarocks --lua-version=5.1 make --local magick-dev-1.rockspec
+	luarocks --lua-version=5.4 make --local magick-dev-1.rockspec
 
 build:
 	moonc magick

--- a/arch-ci.sh
+++ b/arch-ci.sh
@@ -3,10 +3,10 @@ set -e
 set -o pipefail
 set -o xtrace
 
-luarocks --lua-version=5.1 --local make
-eval $(luarocks --lua-version=5.1 --local path)
+luarocks --lua-version=5.4 --local make
+eval $(luarocks --lua-version=5.4 --local path)
 
-cat $(which busted) | sed 's/\/usr\/bin\/lua5\.1/\/usr\/local\/openresty\/luajit\/bin\/luajit/' > busted
+cat $(which busted) | sed 's/\/usr\/bin\/lua5\.4/\/usr\/local\/openresty\/luajit\/bin\/luajit/' > busted
 chmod +x busted
 
 ./busted -o utfTerminal

--- a/magick-dev-1.rockspec
+++ b/magick-dev-1.rockspec
@@ -12,7 +12,7 @@ description = {
 }
 
 dependencies = {
-  "lua == 5.1", -- how to do luajit?
+  "lua == 5.4", -- how to do luajit?
 }
 
 build = {

--- a/magick/gmwand/image.lua
+++ b/magick/gmwand/image.lua
@@ -1,11 +1,11 @@
-local ffi = require("ffi")
+local cffi = require("cffi")
 local lib
 lib = require("magick.gmwand.lib").lib
 local data = require("magick.gmwand.data")
 local get_exception
 get_exception = function(wand)
-  local etype = ffi.new("ExceptionType[1]", 0)
-  local msg = ffi.string(ffi.gc(lib.MagickGetException(wand, etype), lib.MagickRelinquishMemory))
+  local etype = cffi.new("ExceptionType[1]", 0)
+  local msg = cffi.string(cffi.gc(lib.MagickGetException(wand, etype), lib.MagickRelinquishMemory))
   return etype[0], msg
 end
 local handle_result
@@ -24,10 +24,10 @@ do
   local _parent_0 = require("magick.base_image")
   local _base_0 = {
     get_width = function(self)
-      return tonumber(lib.MagickGetImageWidth(self.wand))
+      return cffi.tonumber(lib.MagickGetImageWidth(self.wand))
     end,
     get_height = function(self)
-      return tonumber(lib.MagickGetImageHeight(self.wand))
+      return cffi.tonumber(lib.MagickGetImageHeight(self.wand))
     end,
     get_format = function(self)
       local format = lib.MagickGetImageFormat(self.wand)
@@ -35,7 +35,7 @@ do
         return nil
       end
       do
-        local _with_0 = ffi.string(format):lower()
+        local _with_0 = cffi.string(format):lower()
         lib.MagickRelinquishMemory(format)
         return _with_0
       end
@@ -44,13 +44,13 @@ do
       return handle_result(self, lib.MagickSetImageFormat(self.wand, format))
     end,
     get_depth = function(self)
-      return tonumber(lib.MagickGetImageDepth(self.wand))
+      return cffi.tonumber(lib.MagickGetImageDepth(self.wand))
     end,
     set_depth = function(self, d)
       return handle_result(self, lib.MagickSetImageDepth(self.wand, d))
     end,
     clone = function(self)
-      local wand = ffi.gc(lib.CloneMagickWand(self.wand), lib.DestroyMagickWand)
+      local wand = cffi.gc(lib.CloneMagickWand(self.wand), lib.DestroyMagickWand)
       return Image(wand, self.path)
     end,
     resize = function(self, w, h, filter, blur)
@@ -118,13 +118,13 @@ do
       return handle_result(self, lib.MagickSetCompressionQuality(self.wand, quality))
     end,
     get_blob = function(self)
-      local len = ffi.new("size_t[1]", 0)
-      local blob = ffi.gc(lib.MagickWriteImageBlob(self.wand, len), lib.MagickRelinquishMemory)
-      return ffi.string(blob, len[0])
+      local len = cffi.new("size_t[1]", 0)
+      local blob = cffi.gc(lib.MagickWriteImageBlob(self.wand, len), lib.MagickRelinquishMemory)
+      return cffi.string(blob, len[0])
     end,
     get_colorspace = function(self)
       local out = lib.MagickGetImageColorspace(self.wand)
-      return data.colorspaces:to_str(tonumber(out))
+      return data.colorspaces:to_str(cffi.tonumber(out))
     end,
     set_colorspace = function(self, colorspace)
       colorspace = assert(data.colorspaces:to_int(colorspace), "invalid operator type")
@@ -185,7 +185,7 @@ do
     if fill == nil then
       fill = "none"
     end
-    local wand = ffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
+    local wand = cffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
     if 0 == lib.MagickSetSize(wand, width, height) then
       local code, msg = get_exception(wand)
       return nil, msg, code
@@ -199,7 +199,7 @@ do
     return self(wand, "<blank_image>")
   end
   self.load = function(self, path)
-    local wand = ffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
+    local wand = cffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
     if 0 == lib.MagickReadImage(wand, path) then
       local code, msg = get_exception(wand)
       return nil, msg, code
@@ -207,7 +207,7 @@ do
     return self(wand, path)
   end
   self.load_from_blob = function(self, blob)
-    local wand = ffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
+    local wand = cffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
     if 0 == lib.MagickReadImageBlob(wand, blob, #blob) then
       local code, msg = get_exception(wand)
       return nil, msg, code

--- a/magick/gmwand/image.moon
+++ b/magick/gmwand/image.moon
@@ -1,11 +1,11 @@
 
-ffi = require "ffi"
+cffi = require "cffi"
 import lib from require "magick.gmwand.lib"
 data = require "magick.gmwand.data"
 
 get_exception = (wand) ->
-  etype = ffi.new "ExceptionType[1]", 0
-  msg = ffi.string ffi.gc lib.MagickGetException(wand, etype), lib.MagickRelinquishMemory
+  etype = cffi.new "ExceptionType[1]", 0
+  msg = cffi.string cffi.gc lib.MagickGetException(wand, etype), lib.MagickRelinquishMemory
   etype[0], msg
 
 
@@ -19,7 +19,7 @@ handle_result = (img_or_wand, status) ->
 
 class Image extends require "magick.base_image"
   @blank_image: (width, height, fill="none") =>
-    wand = ffi.gc lib.NewMagickWand!, lib.DestroyMagickWand
+    wand = cffi.gc lib.NewMagickWand!, lib.DestroyMagickWand
 
     if 0 == lib.MagickSetSize wand, width, height
       code, msg = get_exception wand
@@ -38,7 +38,7 @@ class Image extends require "magick.base_image"
     @ wand, "<blank_image>"
 
   @load: (path) =>
-    wand = ffi.gc lib.NewMagickWand!, lib.DestroyMagickWand
+    wand = cffi.gc lib.NewMagickWand!, lib.DestroyMagickWand
     if 0 == lib.MagickReadImage wand, path
       code, msg = get_exception wand
       return nil, msg, code
@@ -46,7 +46,7 @@ class Image extends require "magick.base_image"
     @ wand, path
 
   @load_from_blob: (blob) =>
-    wand = ffi.gc lib.NewMagickWand!, lib.DestroyMagickWand
+    wand = cffi.gc lib.NewMagickWand!, lib.DestroyMagickWand
     if 0 == lib.MagickReadImageBlob wand, blob, #blob
       code, msg = get_exception wand
       return nil, msg, code
@@ -55,15 +55,15 @@ class Image extends require "magick.base_image"
 
   new: (@wand, @path) =>
 
-  get_width: => tonumber lib.MagickGetImageWidth @wand
-  get_height: => tonumber lib.MagickGetImageHeight @wand
+  get_width: => cffi.tonumber lib.MagickGetImageWidth @wand
+  get_height: => cffi.tonumber lib.MagickGetImageHeight @wand
 
   get_format: =>
     format = lib.MagickGetImageFormat(@wand)
     if format == nil
       return nil
 
-    with ffi.string(format)\lower!
+    with cffi.string(format)\lower!
       lib.MagickRelinquishMemory format
 
   set_format: (format) =>
@@ -71,14 +71,14 @@ class Image extends require "magick.base_image"
       lib.MagickSetImageFormat @wand, format
 
   get_depth: =>
-    tonumber lib.MagickGetImageDepth @wand
+    cffi.tonumber lib.MagickGetImageDepth @wand
 
   set_depth: (d) =>
     handle_result @,
       lib.MagickSetImageDepth @wand, d
 
   clone: =>
-    wand = ffi.gc lib.CloneMagickWand(@wand), lib.DestroyMagickWand
+    wand = cffi.gc lib.CloneMagickWand(@wand), lib.DestroyMagickWand
     Image wand, @path
 
   resize: (w,h, filter="Lanczos", blur=1.0) =>
@@ -121,15 +121,15 @@ class Image extends require "magick.base_image"
       lib.MagickSetCompressionQuality @wand, quality
 
   get_blob: =>
-    len = ffi.new "size_t[1]", 0
-    blob = ffi.gc lib.MagickWriteImageBlob(@wand, len),
+    len = cffi.new "size_t[1]", 0
+    blob = cffi.gc lib.MagickWriteImageBlob(@wand, len),
       lib.MagickRelinquishMemory
 
-    ffi.string blob, len[0]
+    cffi.string blob, len[0]
 
   get_colorspace: =>
     out = lib.MagickGetImageColorspace @wand
-    data.colorspaces\to_str tonumber out
+    data.colorspaces\to_str cffi.tonumber out
 
   set_colorspace: (colorspace) =>
     colorspace = assert data.colorspaces\to_int(colorspace), "invalid operator type"

--- a/magick/gmwand/lib.lua
+++ b/magick/gmwand/lib.lua
@@ -1,5 +1,5 @@
-local ffi = require("ffi")
-ffi.cdef([[  void InitializeMagick( const char *path );
+local cffi = require("cffi")
+cffi.cdef([[  void InitializeMagick( const char *path );
   typedef void MagickWand;
   typedef void PixelWand;
   typedef unsigned int MagickPassFail;
@@ -86,7 +86,7 @@ ffi.cdef([[  void InitializeMagick( const char *path );
   MagickPassFail MagickSetSize(MagickWand *,const unsigned long,const unsigned long);
 
 ]])
-local gmwand = ffi.load("GraphicsMagickWand")
+local gmwand = cffi.load("GraphicsMagickWand")
 return {
   lib = gmwand
 }

--- a/magick/gmwand/lib.moon
+++ b/magick/gmwand/lib.moon
@@ -1,10 +1,10 @@
-ffi = require "ffi"
+cffi = require "cffi"
 
 -- /usr/include/GraphicsMagick/magick/api.h
 -- /usr/include/GraphicsMagick/wand/magick_wand.h
 -- /usr/include/GraphicsMagick/wand/pixel_wand.h
 
-ffi.cdef [[
+cffi.cdef [[
   void InitializeMagick( const char *path );
   typedef void MagickWand;
   typedef void PixelWand;
@@ -93,7 +93,7 @@ ffi.cdef [[
 
 ]]
 
-gmwand = ffi.load "GraphicsMagickWand"
+gmwand = cffi.load "GraphicsMagickWand"
 
 { lib: gmwand }
 

--- a/magick/wand/image.lua
+++ b/magick/wand/image.lua
@@ -1,4 +1,4 @@
-local ffi = require("ffi")
+local cffi = require("cffi")
 local lib, can_resize, get_filter
 do
   local _obj_0 = require("magick.wand.lib")
@@ -11,8 +11,8 @@ do
 end
 local get_exception
 get_exception = function(wand)
-  local etype = ffi.new("ExceptionType[1]", 0)
-  local msg = ffi.string(ffi.gc(lib.MagickGetException(wand, etype), lib.MagickRelinquishMemory))
+  local etype = cffi.new("ExceptionType[1]", 0)
+  local msg = cffi.string(cffi.gc(lib.MagickGetException(wand, etype), lib.MagickRelinquishMemory))
   return etype[0], msg
 end
 local handle_result
@@ -39,7 +39,7 @@ do
     get_format = function(self)
       local format = lib.MagickGetImageFormat(self.wand)
       do
-        local _with_0 = ffi.string(format):lower()
+        local _with_0 = cffi.string(format):lower()
         lib.MagickRelinquishMemory(format)
         return _with_0
       end
@@ -48,13 +48,13 @@ do
       return handle_result(self, lib.MagickSetImageFormat(self.wand, format))
     end,
     get_depth = function(self)
-      return tonumber(lib.MagickGetImageDepth(self.wand))
+      return cffi.tonumber(lib.MagickGetImageDepth(self.wand))
     end,
     set_depth = function(self, d)
       return handle_result(self, lib.MagickSetImageDepth(self.wand, d))
     end,
     get_quality = function(self)
-      return lib.MagickGetImageCompressionQuality(self.wand)
+      return cffi.tonumber(lib.MagickGetImageCompressionQuality(self.wand))
     end,
     set_quality = function(self, quality)
       return handle_result(self, lib.MagickSetImageCompressionQuality(self.wand, quality))
@@ -63,7 +63,7 @@ do
       local format = magick .. ":" .. key
       local option_str = lib.MagickGetOption(self.wand, format)
       do
-        local _with_0 = ffi.string(option_str)
+        local _with_0 = cffi.string(option_str)
         lib.MagickRelinquishMemory(option_str)
         return _with_0
       end
@@ -83,11 +83,11 @@ do
       return lib.MagickStripImage(self.wand)
     end,
     clone = function(self)
-      local wand = ffi.gc(lib.CloneMagickWand(self.wand), lib.DestroyMagickWand)
+      local wand = cffi.gc(lib.CloneMagickWand(self.wand), lib.DestroyMagickWand)
       return Image(wand, self.path)
     end,
     coalesce = function(self)
-      self.wand = ffi.gc(lib.MagickCoalesceImages(self.wand), lib.DestroyMagickWand)
+      self.wand = cffi.gc(lib.MagickCoalesceImages(self.wand), lib.DestroyMagickWand)
       return true
     end,
     resize = function(self, w, h, f, blur)
@@ -154,14 +154,14 @@ do
       if b == nil then
         b = 0
       end
-      local pixel = ffi.gc(lib.NewPixelWand(), lib.DestroyPixelWand)
+      local pixel = cffi.gc(lib.NewPixelWand(), lib.DestroyPixelWand)
       lib.PixelSetRed(pixel, r)
       lib.PixelSetGreen(pixel, g)
       lib.PixelSetBlue(pixel, b)
       local res = {
         handle_result(self, lib.MagickRotateImage(self.wand, pixel, degrees))
       }
-      return unpack(res)
+      return table.unpack(res)
     end,
     composite = function(self, blob, x, y, op)
       if op == nil then
@@ -174,25 +174,25 @@ do
       return handle_result(self, lib.MagickCompositeImage(self.wand, blob, op, x, y))
     end,
     get_blob = function(self)
-      local len = ffi.new("size_t[1]", 0)
-      local blob = ffi.gc(lib.MagickGetImageBlob(self.wand, len), lib.MagickRelinquishMemory)
-      return ffi.string(blob, len[0])
+      local len = cffi.new("size_t[1]", 0)
+      local blob = cffi.gc(lib.MagickGetImageBlob(self.wand, len), lib.MagickRelinquishMemory)
+      return cffi.string(blob, len[0])
     end,
     write = function(self, fname)
       return handle_result(self, lib.MagickWriteImage(self.wand, fname))
     end,
     destroy = function(self)
       if self.wand then
-        lib.DestroyMagickWand(ffi.gc(self.wand, nil))
+        lib.DestroyMagickWand(cffi.gc(self.wand, nil))
         self.wand = nil
       end
       if self.pixel_wand then
-        lib.DestroyPixelWand(ffi.gc(self.pixel_wand, nil))
+        lib.DestroyPixelWand(cffi.gc(self.pixel_wand, nil))
         self.pixel_wand = nil
       end
     end,
     get_pixel = function(self, x, y)
-      self.pixel_wand = self.pixel_wand or ffi.gc(lib.NewPixelWand(), lib.DestroyPixelWand)
+      self.pixel_wand = self.pixel_wand or cffi.gc(lib.NewPixelWand(), lib.DestroyPixelWand)
       assert(lib.MagickGetImagePixelColor(self.wand, x, y, self.pixel_wand), "failed to get pixel")
       return lib.PixelGetRed(self.pixel_wand), lib.PixelGetGreen(self.pixel_wand), lib.PixelGetBlue(self.pixel_wand), lib.PixelGetAlpha(self.pixel_wand)
     end,
@@ -212,7 +212,7 @@ do
       local res = lib.MagickGetImageProperty(self.wand, property)
       if nil ~= res then
         do
-          local _with_0 = ffi.string(res)
+          local _with_0 = cffi.string(res)
           lib.MagickRelinquishMemory(res)
           return _with_0
         end
@@ -278,7 +278,7 @@ do
   _base_0.__class = _class_0
   local self = _class_0
   self.load = function(self, path)
-    local wand = ffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
+    local wand = cffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
     if 0 == lib.MagickReadImage(wand, path) then
       local code, msg = get_exception(wand)
       return nil, msg, code
@@ -286,7 +286,7 @@ do
     return self(wand, path)
   end
   self.load_from_blob = function(self, blob)
-    local wand = ffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
+    local wand = cffi.gc(lib.NewMagickWand(), lib.DestroyMagickWand)
     if 0 == lib.MagickReadImageBlob(wand, blob, #blob) then
       local code, msg = get_exception(wand)
       return nil, msg, code

--- a/magick/wand/lib.lua
+++ b/magick/wand/lib.lua
@@ -1,11 +1,10 @@
-local ffi = require("ffi")
+local cffi = require("cffi")
 local lib
-ffi.cdef([[  typedef void MagickWand;
+cffi.cdef([[  typedef void MagickWand;
   typedef void PixelWand;
 
   typedef int MagickBooleanType;
   typedef int ExceptionType;
-  typedef int ssize_t;
   typedef int CompositeOperator;
   typedef int GravityType;
   typedef int OrientationType;
@@ -134,7 +133,7 @@ get_filters = function()
   local prefixes = {
     "/usr/include/ImageMagick",
     "/usr/local/include/ImageMagick",
-    unpack((function()
+    table.unpack((function()
       local _accum_0 = { }
       local _len_0 = 1
       for p in get_flags():gmatch("-I([^%s]+)") do
@@ -160,7 +159,7 @@ get_filters = function()
           end
           local filter_types = content:match("(typedef enum.-FilterTypes?;)")
           if filter_types then
-            ffi.cdef(filter_types)
+            cffi.cdef(filter_types)
             if filter_types:match("FilterTypes;") then
               return "FilterTypes"
             end
@@ -180,7 +179,7 @@ local can_resize
 do
   local enum_name = get_filters()
   if enum_name then
-    ffi.cdef([[    MagickBooleanType MagickResizeImage(MagickWand*,
+    cffi.cdef([[    MagickBooleanType MagickResizeImage(MagickWand*,
       const size_t, const size_t,
       const ]] .. enum_name .. [[, const double);
   ]])
@@ -205,7 +204,7 @@ try_to_load = function(...)
         end
       end
       if pcall(function()
-        out = ffi.load(name)
+        out = cffi.load(name)
       end) then
         return out
       end
@@ -220,9 +219,9 @@ end
 lib = try_to_load("MagickWand", function()
   local lname = get_flags():match("-l(MagickWand[^%s]*)")
   local suffix
-  if ffi.os == "OSX" then
+  if cffi.os == "OSX" then
     suffix = ".dylib"
-  elseif ffi.os == "Windows" then
+  elseif cffi.os == "Windows" then
     suffix = ".dll"
   else
     suffix = ".so"


### PR DESCRIPTION
Thanks for the plugin! I ported this to *Lua* v5.4, so I can use <https://github.com/3rd/image.nvim> for <https://github.com/benlubas/molten-nvim>.

I switched to the CFFI library [q66/cffi-lua: A portable C FFI for Lua 5.1+](https://github.com/q66/cffi-lua).

I tested this via `make test`. All tests pass.

I haven't tested this on *GraphicsMagick*, but made the same changes.

Hope you have time to look at this.